### PR TITLE
👌 Do not create target directory upon initializing a collection

### DIFF
--- a/sphinxcontrib/collections/collections.py
+++ b/sphinxcontrib/collections/collections.py
@@ -81,9 +81,6 @@ class Collection:
                 os.makedirs(collection_main_folder, exist_ok=True)
             target = os.path.join(collection_main_folder, target)
 
-        if not os.path.exists(os.path.dirname(target)):
-            os.makedirs(os.path.dirname(target), exist_ok=True)
-
         self.target = target
 
         clean = kwargs.get("clean")


### PR DESCRIPTION
Currently, a collection always creates the target directory upon initialization. This leads to the issue that the symlink driver (and also the jinja driver) does not work as expected.

Not creating a target directory upon collection initialization fixes this issue.

Resolves #22 