### PR TITLE
Update poetry dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,6 @@ profile = "black"
 docs = ["sphinx"]
 
 [build-system]
-requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@master"]
+requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@main"]
 build-backend = "poetry.core.masonry.api"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ line-length = 120
 profile = "black"
 
 [tool.poetry.extras]
-docs = ["sphinx>=4.0"]
+docs = ["sphinx"]
 
 [build-system]
 requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@master"]


### PR DESCRIPTION
To build all useblocks sphinx-extensions with same poetry version, update pyproject.toml to work with newer poetry version