### PR TITLE
🐛 Fix Sphinx 9 compatibility (Tags.tags removed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,10 @@ jobs:
           - py311-sphinx82
           - py312-sphinx74
           - py312-sphinx82
+          - py312-sphinx91
           - py313-sphinx74
           - py313-sphinx82
+          - py313-sphinx91
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ legacy_tox_ini = """
 [tox]
 env_list =
     py{310,311,312,313}-sphinx{74,82}
+    py{312,313}-sphinx91
     docs
     linkcheck
 requires =
@@ -96,6 +97,7 @@ deps =
     pytest-xdist>=3.0
     sphinx74: sphinx==7.4.*
     sphinx82: sphinx==8.2.*
+    sphinx91: sphinx==9.1.*
 extras = docs
 commands =
     pytest -n auto --tb=long tests/

--- a/sphinx_collections/collections.py
+++ b/sphinx_collections/collections.py
@@ -66,7 +66,7 @@ class Collection:
         # Check if tags are set and change active to True if this is the case
         self.tags = tags
         for tag in tags:
-            if self.app.tags.tags.get(tag):
+            if tag in self.app.tags:
                 self.active = True
 
         self._prefix = f"  {self.name}: "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,16 +1,16 @@
 """Pytest conftest module containing common test configuration and fixtures."""
 
+from pathlib import Path
 import shutil
 
 import pytest
-from sphinx.testing.path import path
 
 pytest_plugins = "sphinx.testing.fixtures"
 
 
 def copy_srcdir_to_tmpdir(srcdir, tmp):
-    srcdir = path(__file__).parent.abspath() / srcdir
-    tmproot = tmp / path(srcdir).basename()
+    srcdir = Path(__file__).parent.resolve() / srcdir
+    tmproot = Path(tmp) / Path(srcdir).name
     shutil.copytree(srcdir, tmproot)
     return tmproot
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,18 @@ import shutil
 
 import pytest
 
+from sphinx_collections import collections as _collections_module
+
 pytest_plugins = "sphinx.testing.fixtures"
+
+
+@pytest.fixture(autouse=True)
+def _reset_collections_registry():
+    # Why: COLLECTIONS is a module-level list mutated by config-inited handlers,
+    # so it leaks between tests sharing an xdist worker.
+    _collections_module.COLLECTIONS.clear()
+    yield
+    _collections_module.COLLECTIONS.clear()
 
 
 def copy_srcdir_to_tmpdir(srcdir, tmp):

--- a/tests/doc_test/config_tags/conf.py
+++ b/tests/doc_test/config_tags/conf.py
@@ -1,0 +1,24 @@
+extensions = ["sphinx_collections"]
+
+collections = {
+    "active_via_tag": {
+        "driver": "string",
+        "source": "Tag activated content",
+        "target": "active_via_tag/file.txt",
+        "active": False,
+        "tags": ["enable_collection"],
+        "final_clean": False,
+    },
+    "inactive_no_tag": {
+        "driver": "string",
+        "source": "Should not appear",
+        "target": "inactive_no_tag/file.txt",
+        "active": False,
+        "tags": ["never_set_tag"],
+        "final_clean": False,
+    },
+}
+
+project = "collections tag test"
+master_doc = "index"
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]

--- a/tests/doc_test/config_tags/index.rst
+++ b/tests/doc_test/config_tags/index.rst
@@ -1,0 +1,4 @@
+TEST COLLECTIONS TAG ACTIVATION
+===============================
+
+Tag activated collection works.

--- a/tests/test_config_tags.py
+++ b/tests/test_config_tags.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/config_tags", "tags": ["enable_collection"]}],
+    indirect=True,
+)
+def test_tag_activates_collection(test_app):
+    app = test_app
+    app.build()
+
+    activated = Path(app.confdir, "_collections", "active_via_tag", "file.txt")
+    assert activated.exists()
+    assert activated.read_text() == "Tag activated content"
+
+    inactive = Path(app.confdir, "_collections", "inactive_no_tag", "file.txt")
+    assert not inactive.exists()
+
+
+@pytest.mark.parametrize(
+    "test_app",
+    [{"buildername": "html", "srcdir": "doc_test/config_tags"}],
+    indirect=True,
+)
+def test_no_tag_keeps_collection_inactive(test_app):
+    app = test_app
+    app.build()
+
+    activated = Path(app.confdir, "_collections", "active_via_tag", "file.txt")
+    inactive = Path(app.confdir, "_collections", "inactive_no_tag", "file.txt")
+    assert not activated.exists()
+    assert not inactive.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -664,7 +664,7 @@ wheels = [
 
 [[package]]
 name = "sphinx-collections"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
## Summary

- Replace `app.tags.tags.get(tag)` with `tag in app.tags` in `Collection.__init__`. Sphinx 9 removed the deprecated `Tags.tags` mapping; the `__contains__` API has been stable since Sphinx 1.4.
- Update `tests/conftest.py` to use `pathlib.Path` instead of `sphinx.testing.path`, which was also removed in Sphinx 9.
- Add Sphinx 9.1 to the tox env list and CI matrix (Python 3.12 and 3.13, since Sphinx 9 requires Python ≥3.12).
- Add a regression test (`tests/test_config_tags.py` + `tests/doc_test/config_tags/`) that builds a doc with a tag-activated collection and asserts both the active and inactive paths.

## Fixes

Closes #47

## Test plan

- [x] `pytest tests/` passes on Sphinx 7.4, 8.2, and 9.1
- [x] Regression test fails without the fix (reproduces `'Tags' object has no attribute 'tags'`)
- [x] `ruff check` and `ruff format --check` clean
- [x] CI matrix runs `py{312,313}-sphinx91` successfully