### PR TITLE
🚀 Release v0.3.2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+.. _`release:0.3.2`:
+
+0.3.2
+-----
+
+:Released: 22.06.2026
+:Full Changelog: `v0.3.1...v0.3.2 <https://github.com/useblocks/sphinx-collections/compare/0.3.1...0.3.2>`__
+
+- 🐛 Fix Sphinx 9 compatibility (``Tags.tags`` removed) (:pr:`48`)
+
 - 🔧 Move directory handling for targets to drivers instead of collection (:issue:`22`)
 
 .. _`release:0.3.1`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "sphinx-collections"
-version = "0.3.1"
+version = "0.3.2"
 description = "Sphinx collections extension for mapping directories and services as document folders"
 readme = "README.rst"
 license = { text = "MIT" }

--- a/sphinx_collections/main.py
+++ b/sphinx_collections/main.py
@@ -21,7 +21,7 @@ else:
     logging.basicConfig()  # Only need to do this once
 
 LOG = logging.getLogger(__name__)
-VERSION = "0.3.1"
+VERSION = "0.3.2"
 
 
 def setup(app):


### PR DESCRIPTION
Release **v0.3.2**.

Bumps the version (`0.3.1` → `0.3.2`) in `pyproject.toml` and `sphinx_collections/main.py`, and stamps the `0.3.2` section in `docs/changelog.rst`.

### Highlights since v0.3.1

- 🐛 Fix Sphinx 9 compatibility (`Tags.tags` removed) (#48)
- 🔧 Move directory handling for targets to drivers instead of collection (#22)
- ⬆️ Dependency & CI maintenance — GitHub Actions (`checkout`, `upload-artifact`, `download-artifact`) and Python dependencies (`pytest` 9, `uv`, `gitpython`, `pygments`, `urllib3`, `idna`, `requests`, `virtualenv`)

### Publishing

After this PR is merged, push the tag `0.3.2` to trigger the `Release` workflow (trusted publishing to PyPI). The workflow fires on tags matching `N.N.N`.
